### PR TITLE
fix: uncomment drop statement sql in d1 schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS telegram_messages;
 CREATE TABLE telegram_messages (
     update_id INTEGER PRIMARY KEY,
     message_id INTEGER,

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,4 @@
--- DROP TABLE IF EXISTS telegram_messages;
+DROP TABLE IF EXISTS telegram_messages;
 CREATE TABLE telegram_messages (
     update_id INTEGER PRIMARY KEY,
     message_id INTEGER,


### PR DESCRIPTION
### Issue

![fix_tg_bot_pr](https://image.pseudoyu.com/images/fix_tg_bot_pr.jpg)

The `wrangler d1 execute` command fails to recognize SQL files that with a comment line `--`, making the commandline execution failed.

### Solution

- SQL file commands can now be made effective by uncommenting the first line `DROP TABLE IF EXISTS telegram_messages;`